### PR TITLE
Compatible issue with linum-mode and git-gutter in Emacs 26.1

### DIFF
--- a/init.el
+++ b/init.el
@@ -265,7 +265,7 @@
 
 
 ;; 行番号を常に表示させる
-(global-linum-mode)
+(global-display-line-numbers-mode t)
 (setq linum-format "%4d ")
 ;;(set-face-attribute 'linum nil
 ;;	    :background "#282c34"


### PR DESCRIPTION
Moving the cursor with linum-mode and git-gutter, all rows advance forward 😂 


![image](https://user-images.githubusercontent.com/12762000/48313064-92116b80-e5fa-11e8-899b-af0712a9d5bb.png)


- https://github.com/syohex/emacs-git-gutter/issues/156